### PR TITLE
Change managed_state_projection from JSON string to flat map

### DIFF
--- a/internal/k8sconnect/common/k8sclient/retry.go
+++ b/internal/k8sconnect/common/k8sclient/retry.go
@@ -222,6 +222,12 @@ func isRetryableError(err error) bool {
 		return true
 	}
 
+	// Discovery errors - CRD/CR timing issues (API server discovery cache not updated yet)
+	if strings.Contains(errMsg, "could not find the requested resource") ||
+		strings.Contains(errMsg, "no matches for kind") {
+		return true
+	}
+
 	// Default: don't retry unknown errors
 	return false
 }

--- a/internal/k8sconnect/resource/manifest/basic_test.go
+++ b/internal/k8sconnect/resource/manifest/basic_test.go
@@ -534,7 +534,8 @@ func TestAccManifestResource_CreateShowsProjection(t *testing.T) {
 				},
 				Check: resource.ComposeTestCheckFunc(
 					testhelpers.CheckConfigMapExists(k8sClient, ns, cmName),
-					resource.TestCheckResourceAttrSet("k8sconnect_manifest.test_cm", "managed_state_projection"),
+					// Check that managed_state_projection map has elements (% gives count)
+					resource.TestCheckResourceAttrSet("k8sconnect_manifest.test_cm", "managed_state_projection.%"),
 				),
 			},
 		},

--- a/internal/k8sconnect/resource/manifest/crud.go
+++ b/internal/k8sconnect/resource/manifest/crud.go
@@ -122,7 +122,8 @@ func (r *manifestResource) Read(ctx context.Context, req resource.ReadRequest, r
 			tflog.Warn(ctx, "Projection still failing during refresh, keeping pending flag", map[string]interface{}{
 				"error": err.Error(),
 			})
-			data.ManagedStateProjection = types.StringValue("{}")
+			emptyMap, _ := types.MapValueFrom(ctx, types.StringType, map[string]string{})
+			data.ManagedStateProjection = emptyMap
 			setPendingProjectionFlag(ctx, resp.Private)
 		} else {
 			resp.Diagnostics.AddError("Projection Failed",
@@ -357,8 +358,10 @@ func handleProjectionFailure(
 		"error": err.Error(),
 	})
 
-	// Set empty projection
-	rc.Data.ManagedStateProjection = types.StringValue("{}")
+	// Set empty projection and field ownership - both must be known for Terraform to save state
+	emptyMap, _ := types.MapValueFrom(ctx, types.StringType, map[string]string{})
+	rc.Data.ManagedStateProjection = emptyMap
+	rc.Data.FieldOwnership = emptyMap
 
 	// Save state with pending projection flag in Private state
 	setPendingProjectionFlag(ctx, privateSetter)

--- a/internal/k8sconnect/resource/manifest/drift_test.go
+++ b/internal/k8sconnect/resource/manifest/drift_test.go
@@ -48,7 +48,7 @@ func TestAccManifestResource_DriftDetection(t *testing.T) {
 				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("k8sconnect_manifest.drift_test", "id"),
-					resource.TestCheckResourceAttrSet("k8sconnect_manifest.drift_test", "managed_state_projection"),
+					resource.TestCheckResourceAttrSet("k8sconnect_manifest.drift_test", "managed_state_projection.%"),
 					testhelpers.CheckConfigMapExists(k8sClient, ns, cmName),
 				),
 			},

--- a/internal/k8sconnect/resource/manifest/import_test.go
+++ b/internal/k8sconnect/resource/manifest/import_test.go
@@ -128,7 +128,7 @@ func TestAccManifestResource_ImportWithManagedFields(t *testing.T) {
 					testhelpers.CheckConfigMapExists(k8sClient, ns, configMapName),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "yaml_body"),
-					resource.TestCheckResourceAttrSet(resourceName, "managed_state_projection"),
+					resource.TestCheckResourceAttrSet(resourceName, "managed_state_projection.%"),
 				),
 			},
 			// Step 2: Import the same resource

--- a/internal/k8sconnect/resource/manifest/manifest.go
+++ b/internal/k8sconnect/resource/manifest/manifest.go
@@ -44,7 +44,7 @@ type manifestResourceModel struct {
 	FieldOwnership         types.Map     `tfsdk:"field_ownership"`
 	ForceDestroy           types.Bool    `tfsdk:"force_destroy"`
 	IgnoreFields           types.List    `tfsdk:"ignore_fields"`
-	ManagedStateProjection types.String  `tfsdk:"managed_state_projection"`
+	ManagedStateProjection types.Map     `tfsdk:"managed_state_projection"`
 	WaitFor                types.Object  `tfsdk:"wait_for"`
 	Status                 types.Dynamic `tfsdk:"status"`
 }
@@ -133,12 +133,14 @@ func (r *manifestResource) Schema(ctx context.Context, req resource.SchemaReques
 				Optional:            true,
 				MarkdownDescription: `Force deletion by removing finalizers. ⚠️ **WARNING**: Unlike other providers, this REMOVES finalizers after timeout. May cause data loss and orphaned cloud resources. See docs before using.`,
 			},
-			"managed_state_projection": schema.StringAttribute{
-				Computed: true,
-				Description: "Snapshot of resource state from the last Server-Side Apply dry-run, containing only fields managed by k8sconnect. " +
+			"managed_state_projection": schema.MapAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+				Description: "Field-by-field snapshot of managed state as flat key-value pairs with dotted paths. " +
+					"Shows exactly which fields k8sconnect manages and their current values. " +
+					"Terraform automatically displays only changed keys in diffs for clean, scannable output. " +
 					"When this differs from current cluster state, it indicates drift - someone modified your managed fields outside Terraform. " +
-					"During plan, diffs in this attribute show exactly what Kubernetes will change when you apply, computed via dry-run for accuracy. " +
-					"This enables precise drift detection without false positives from fields managed by other controllers.",
+					"Computed via Server-Side Apply dry-run for accuracy, enabling precise drift detection without false positives.",
 			},
 			"ignore_fields": schema.ListAttribute{
 				Optional:    true,

--- a/internal/k8sconnect/resource/manifest/quantity_test.go
+++ b/internal/k8sconnect/resource/manifest/quantity_test.go
@@ -43,7 +43,7 @@ func TestAccManifestResource_QuantityNormalization(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					// Initial apply should succeed
 					resource.TestCheckResourceAttrSet("k8sconnect_manifest.test_quota", "id"),
-					resource.TestCheckResourceAttrSet("k8sconnect_manifest.test_quota", "managed_state_projection"),
+					resource.TestCheckResourceAttrSet("k8sconnect_manifest.test_quota", "managed_state_projection.%"),
 				),
 			},
 			{


### PR DESCRIPTION
  - Convert ManagedStateProjection schema from types.String to types.Map
  - Add flattenProjectionToMap() to display field paths as dotted keys
  - Fix handleProjectionFailure to set FieldOwnership to empty map (prevents unknown
   field errors)
  - Add discovery error retry support for CRD/CR timing race conditions
  - Update all projection setters to use Map instead of JSON string
  - Update test assertions to check map.% instead of string attribute