### PR TITLE
Bump gosec from 2.23.0 to 2.25.0

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@v2.23.0  # Pin to stable version instead of @master
+        uses: securego/gosec@v2.25.0
         with:
           args: '-no-fail -fmt sarif -out gosec-results.sarif ./...'
       


### PR DESCRIPTION
Skips 2.24.x which has a broken SARIF output format ([securego/gosec#1568](https://github.com/securego/gosec/issues/1568)). v2.25.0 fixes the issue.