### PR TITLE
wait: poll for non-existent resources + ADR-023 GVR auth fix

### DIFF
--- a/internal/k8sconnect/resource/object/crud.go
+++ b/internal/k8sconnect/resource/object/crud.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/jmorris0x0/terraform-provider-k8sconnect/internal/k8sconnect/common"
 	"github.com/jmorris0x0/terraform-provider-k8sconnect/internal/k8sconnect/common/k8sclient"
+	"github.com/jmorris0x0/terraform-provider-k8sconnect/internal/k8sconnect/common/k8serrors"
 )
 
 func (r *objectResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -110,6 +111,28 @@ func (r *objectResource) Read(ctx context.Context, req resource.ReadRequest, res
 	// 2. Setup context
 	rc, err := r.prepareContext(ctx, &data, false, false)
 	if err != nil {
+		// ADR-023: GVR discovery during Read can fail with an auth error when the
+		// token stored in state has expired between Terraform runs. Degrade to a
+		// warning and preserve prior state; ModifyPlan will retry drift detection
+		// with the fresh token from Config.
+		if k8serrors.IsAuthError(err) {
+			resourceDesc := "resource"
+			if !data.YAMLBody.IsNull() && data.YAMLBody.ValueString() != "" {
+				if obj, parseErr := r.parseYAML(data.YAMLBody.ValueString()); parseErr == nil {
+					resourceDesc = fmt.Sprintf("%s %s", obj.GetKind(), obj.GetName())
+				}
+			}
+			resp.Diagnostics.AddWarning(
+				"Read: Using Prior State — Authentication Failed",
+				fmt.Sprintf("Could not refresh %s from cluster: discovery failed with authentication error. "+
+					"Using prior state. This typically means the stored token has expired "+
+					"between Terraform runs. Details: %v", resourceDesc, err),
+			)
+			setStaleReadFlag(ctx, resp.Private)
+			diags = resp.State.Set(ctx, &data)
+			resp.Diagnostics.Append(diags...)
+			return
+		}
 		resp.Diagnostics.AddError("Preparation Failed", err.Error())
 		return
 	}

--- a/internal/k8sconnect/resource/object/expired_token_test.go
+++ b/internal/k8sconnect/resource/object/expired_token_test.go
@@ -2,6 +2,7 @@ package object_test
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"testing"
@@ -16,8 +17,10 @@ import (
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	"github.com/jmorris0x0/terraform-provider-k8sconnect/internal/k8sconnect"
 	testhelpers "github.com/jmorris0x0/terraform-provider-k8sconnect/internal/k8sconnect/common/test"
@@ -93,9 +96,13 @@ func TestAccObjectResource_ExpiredToken_PlanSucceeds(t *testing.T) {
 			//                ModifyPlan uses fresh token2 from Config → succeeds → plan works
 			{
 				PreConfig: func() {
-					// Delete SA1 to invalidate token1 (instant — no waiting for expiry)
+					// Delete SA1 to invalidate token1
 					deleteServiceAccount(t, k8sClient, ctx, saName1)
 					t.Log("Deleted SA1 — token1 is now invalid")
+					// Confirm token1 is actually rejected before continuing. Without this,
+					// the K8s API server may still accept token1 briefly (cached) and the
+					// auth-error path won't be exercised, defeating the test's purpose.
+					waitForTokenRejection(t, host, ca, token1)
 				},
 				Config: testAccExpiredTokenConfig(ns, cmName),
 				ConfigVariables: config.Variables{
@@ -184,6 +191,9 @@ func TestAccObjectResource_ExpiredToken_DriftDetected(t *testing.T) {
 					// Invalidate token1
 					deleteServiceAccount(t, k8sClient, ctx, saName1)
 					t.Log("Deleted SA1 — token1 is now invalid")
+					// Wait for the rejection to actually take effect (see comment in
+					// the PlanSucceeds test for why this is required).
+					waitForTokenRejection(t, host, ca, token1)
 
 					// Externally modify the ConfigMap
 					cm, err := k8sClient.CoreV1().ConfigMaps(ns).Get(ctx, cmName, metav1.GetOptions{})
@@ -287,6 +297,46 @@ func deleteServiceAccount(t *testing.T, client kubernetes.Interface, ctx context
 
 	_ = client.CoreV1().ServiceAccounts("default").Delete(ctx, saName, metav1.DeleteOptions{})
 	_ = client.RbacV1().ClusterRoleBindings().Delete(ctx, saName+"-admin", metav1.DeleteOptions{})
+}
+
+// waitForTokenRejection polls the K8s API with the given token until it is rejected
+// (401/403) or the deadline expires. This makes ADR-023 tests deterministic across
+// environments: on fast networks (CI Linux), SA-deletion propagation may lag the next
+// API call enough that the token still validates; this loop guarantees we don't proceed
+// until the token is genuinely rejected.
+func waitForTokenRejection(t *testing.T, host, caBase64, token string) {
+	t.Helper()
+
+	caBytes, err := base64.StdEncoding.DecodeString(caBase64)
+	if err != nil {
+		t.Fatalf("failed to decode CA: %v", err)
+	}
+
+	config := &rest.Config{
+		Host:        host,
+		BearerToken: token,
+		TLSClientConfig: rest.TLSClientConfig{
+			CAData: caBytes,
+		},
+	}
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("failed to build polling client: %v", err)
+	}
+
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		_, err := client.Discovery().ServerResourcesForGroupVersion("v1")
+		if err != nil {
+			if apierrors.IsUnauthorized(err) || apierrors.IsForbidden(err) {
+				t.Log("Confirmed token rejected by API server")
+				return
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatal("Token still accepted by API server after 30s; SA deletion did not propagate. " +
+		"ADR-023 tests cannot reliably exercise the auth-error path until this resolves.")
 }
 
 func testAccExpiredTokenConfig(namespace, cmName string) string {

--- a/internal/k8sconnect/resource/wait/crud.go
+++ b/internal/k8sconnect/resource/wait/crud.go
@@ -3,6 +3,7 @@ package wait
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -10,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/jmorris0x0/terraform-provider-k8sconnect/internal/k8sconnect/common"
@@ -254,34 +256,107 @@ func (r *waitResource) constructGVR(ctx context.Context, client k8sclient.K8sCli
 	return gvr, nil
 }
 
-// performWait executes the wait operation
+// performWait executes the wait operation.
+//
+// If the object doesn't exist yet, performWait polls for its creation, bounded
+// by the configured wait_for.timeout. This supports the common pattern of
+// waiting on resources that are created lazily by operators (e.g., Stackgres
+// creating Services, cert-manager creating Secrets, ALB controller creating
+// ALBs). See issue #171.
 func (r *waitResource) performWait(ctx context.Context, wc *waitContext) error {
-	// Get the current object to verify it exists
-	obj, err := wc.Client.Get(ctx, wc.GVR, wc.ObjectRef.Namespace.ValueString(), wc.ObjectRef.Name.ValueString())
+	obj, err := r.waitForExistence(ctx, wc)
 	if err != nil {
-		// Check if this is a not-found error and provide helpful context
-		if errors.IsNotFound(err) {
-			// Build resource description
-			resourceDesc := fmt.Sprintf("%s %q", wc.ObjectRef.Kind.ValueString(), wc.ObjectRef.Name.ValueString())
-			if !wc.ObjectRef.Namespace.IsNull() && wc.ObjectRef.Namespace.ValueString() != "" {
-				resourceDesc = fmt.Sprintf("%s (namespace: %q)", resourceDesc, wc.ObjectRef.Namespace.ValueString())
-			}
-
-			return fmt.Errorf("%s was not found.\n\n"+
-				"k8sconnect_wait can only wait on existing resources. The resource must be created before wait can begin.\n\n"+
-				"Possible causes:\n"+
-				"1. The resource hasn't been created yet\n"+
-				"2. There's a typo in the resource name or namespace\n"+
-				"3. Missing depends_on relationship\n\n"+
-				"If the resource is created in this same Terraform config, add a depends_on:\n"+
-				"  depends_on = [k8sconnect_object.my_resource]",
-				resourceDesc)
-		}
-		return fmt.Errorf("failed to get resource: %w", err)
+		return err
 	}
 
 	// Execute wait logic based on wait_for configuration
 	return r.waitForResource(ctx, wc.Client, wc.GVR, obj, wc.WaitConfig)
+}
+
+// waitForExistence polls for the configured object to exist, bounded by the
+// wait_for.timeout. Returns the object once it appears. Returns an error if
+// the object never appears within the timeout, or if Get returns a non-NotFound
+// error.
+func (r *waitResource) waitForExistence(ctx context.Context, wc *waitContext) (*unstructured.Unstructured, error) {
+	namespace := wc.ObjectRef.Namespace.ValueString()
+	name := wc.ObjectRef.Name.ValueString()
+
+	// Fast path: object already exists
+	obj, err := wc.Client.Get(ctx, wc.GVR, namespace, name)
+	if err == nil {
+		return obj, nil
+	}
+	if !errors.IsNotFound(err) {
+		return nil, fmt.Errorf("failed to get resource: %w", err)
+	}
+
+	// Object doesn't exist yet. Poll for its creation, bounded by the wait timeout.
+	timeout := parseTimeout(wc.WaitConfig.Timeout)
+
+	tflog.Info(ctx, "Resource not found, polling for existence", map[string]interface{}{
+		"kind":      wc.ObjectRef.Kind.ValueString(),
+		"name":      name,
+		"namespace": namespace,
+		"timeout":   timeout.String(),
+	})
+
+	pollCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	const pollInterval = 2 * time.Second
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-pollCtx.Done():
+			// Distinguish wait timeout from caller cancellation
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			resourceDesc := fmt.Sprintf("%s %q", wc.ObjectRef.Kind.ValueString(), name)
+			if namespace != "" {
+				resourceDesc = fmt.Sprintf("%s (namespace: %q)", resourceDesc, namespace)
+			}
+			return nil, fmt.Errorf("%s did not appear within %s.\n\n"+
+				"k8sconnect_wait polls for the referenced resource to be created, but it never appeared.\n\n"+
+				"Possible causes:\n"+
+				"1. The resource was never created (typo in name/namespace, or the operator that creates it never ran)\n"+
+				"2. The resource creation is slow; increase wait_for.timeout\n"+
+				"3. The cluster connection or permissions are wrong",
+				resourceDesc, timeout)
+
+		case <-ticker.C:
+			obj, err := wc.Client.Get(ctx, wc.GVR, namespace, name)
+			if err == nil {
+				tflog.Info(ctx, "Resource appeared, proceeding with wait", map[string]interface{}{
+					"kind":      wc.ObjectRef.Kind.ValueString(),
+					"name":      name,
+					"namespace": namespace,
+				})
+				return obj, nil
+			}
+			if !errors.IsNotFound(err) {
+				return nil, fmt.Errorf("failed to get resource while polling for existence: %w", err)
+			}
+			// Still not found, keep polling
+		}
+	}
+}
+
+// parseTimeout reads wait_for.timeout, falling back to 10m if unset or invalid.
+// Mirrors the parsing in waitForResource so existence polling honors the same
+// timeout the user configured for the wait condition.
+func parseTimeout(t types.String) time.Duration {
+	const defaultTimeout = 10 * time.Minute
+	if t.IsNull() || t.ValueString() == "" {
+		return defaultTimeout
+	}
+	d, err := time.ParseDuration(t.ValueString())
+	if err != nil {
+		return defaultTimeout
+	}
+	return d
 }
 
 // waitForResource is implemented in wait_logic.go

--- a/internal/k8sconnect/resource/wait/wait_existence_test.go
+++ b/internal/k8sconnect/resource/wait/wait_existence_test.go
@@ -1,0 +1,351 @@
+package wait_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/jmorris0x0/terraform-provider-k8sconnect/internal/k8sconnect"
+	testhelpers "github.com/jmorris0x0/terraform-provider-k8sconnect/internal/k8sconnect/common/test"
+)
+
+// TestAccWaitResource_PollsForResourceToExist verifies that when a wait resource
+// references a Kubernetes object that doesn't exist yet, the wait polls for
+// existence (bounded by the configured timeout) instead of failing immediately.
+//
+// This is the use case from issue #171: operators (Stackgres, cert-manager,
+// ALB controller, Karpenter, Crossplane, etc.) create downstream resources
+// lazily after their CR is reconciled. Users need to wait on those downstream
+// resources without knowing exactly when they will appear.
+//
+// Timing strategy:
+//
+//	terraform-plugin-testing setup typically takes ~60s before the apply phase
+//	starts and the wait resource Create runs. We delay the goroutine for 90s
+//	so the Service appears AFTER wait Create has started polling, deterministically
+//	exercising the polling code path regardless of machine speed.
+func TestAccWaitResource_PollsForResourceToExist(t *testing.T) {
+	t.Parallel()
+
+	raw := os.Getenv("TF_ACC_KUBECONFIG")
+	if raw == "" {
+		t.Fatal("TF_ACC_KUBECONFIG must be set")
+	}
+
+	k8sClient := testhelpers.CreateK8sClient(t, raw)
+	nsName := fmt.Sprintf("wait-exist-%d", time.Now().UnixNano()%1000000)
+	svcName := fmt.Sprintf("delayed-svc-%d", time.Now().UnixNano()%1000000)
+
+	// Pre-create namespace directly so the wait resource has somewhere to find the Service
+	testhelpers.CreateNamespaceDirectly(t, k8sClient, nsName)
+	t.Cleanup(func() {
+		_ = k8sClient.CoreV1().Namespaces().Delete(context.Background(), nsName, metav1.DeleteOptions{})
+	})
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"k8sconnect": providerserver.NewProtocol6WithError(k8sconnect.New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					// Simulate an operator creating the Service ~90 seconds into the test.
+					// This is well past the typical ~60s of terraform-plugin-testing setup,
+					// ensuring wait Create has already started polling when this fires.
+					go func() {
+						time.Sleep(90 * time.Second)
+						if err := createServiceDirectly(k8sClient, nsName, svcName); err != nil {
+							fmt.Printf("Background Service creation failed: %v\n", err)
+						} else {
+							fmt.Printf("✅ Background goroutine created Service %s/%s\n", nsName, svcName)
+						}
+					}()
+				},
+				Config: testAccWaitConfigPollExistence(nsName, svcName),
+				ConfigVariables: config.Variables{
+					"raw": config.StringVariable(raw),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testhelpers.CheckServiceExists(k8sClient, nsName, svcName),
+					resource.TestCheckResourceAttrSet("k8sconnect_wait.delayed", "id"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccWaitResource_TimesOutWhenResourceNeverAppears verifies that when a wait
+// resource references an object that never gets created, the wait times out
+// cleanly with a clear error message that distinguishes "object never appeared"
+// from "object was deleted" or "wait condition not met."
+//
+// The error message regex is intentionally strict: it matches only the NEW
+// post-polling error message ("did not appear" / "never appeared within").
+// This causes the test to FAIL on the pre-fix codebase, which emits the
+// fast-fail "was not found" error instead.
+func TestAccWaitResource_TimesOutWhenResourceNeverAppears(t *testing.T) {
+	t.Parallel()
+
+	raw := os.Getenv("TF_ACC_KUBECONFIG")
+	if raw == "" {
+		t.Fatal("TF_ACC_KUBECONFIG must be set")
+	}
+
+	k8sClient := testhelpers.CreateK8sClient(t, raw)
+	nsName := fmt.Sprintf("wait-noexist-%d", time.Now().UnixNano()%1000000)
+	svcName := fmt.Sprintf("never-svc-%d", time.Now().UnixNano()%1000000)
+
+	testhelpers.CreateNamespaceDirectly(t, k8sClient, nsName)
+	t.Cleanup(func() {
+		_ = k8sClient.CoreV1().Namespaces().Delete(context.Background(), nsName, metav1.DeleteOptions{})
+	})
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"k8sconnect": providerserver.NewProtocol6WithError(k8sconnect.New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWaitConfigPollExistenceShortTimeout(nsName, svcName),
+				ConfigVariables: config.Variables{
+					"raw": config.StringVariable(raw),
+				},
+				ExpectError: regexp.MustCompile(`(?s)Wait Operation Failed.*(did not appear|never appeared)`),
+			},
+		},
+	})
+}
+
+func testAccWaitConfigPollExistence(namespace, svcName string) string {
+	return fmt.Sprintf(`
+variable "raw" {
+  type = string
+}
+
+provider "k8sconnect" {}
+
+resource "k8sconnect_wait" "delayed" {
+  object_ref = {
+    api_version = "v1"
+    kind        = "Service"
+    name        = %q
+    namespace   = %q
+  }
+
+  cluster = {
+    kubeconfig = var.raw
+  }
+
+  wait_for = {
+    field   = "spec.clusterIP"
+    timeout = "180s"
+  }
+}
+`, svcName, namespace)
+}
+
+func testAccWaitConfigPollExistenceShortTimeout(namespace, svcName string) string {
+	return fmt.Sprintf(`
+variable "raw" {
+  type = string
+}
+
+provider "k8sconnect" {}
+
+resource "k8sconnect_wait" "missing" {
+  object_ref = {
+    api_version = "v1"
+    kind        = "Service"
+    name        = %q
+    namespace   = %q
+  }
+
+  cluster = {
+    kubeconfig = var.raw
+  }
+
+  wait_for = {
+    field   = "spec.clusterIP"
+    timeout = "5s"
+  }
+}
+`, svcName, namespace)
+}
+
+// TestAccWaitResource_PollsForClusterScopedResource verifies polling works for
+// cluster-scoped resources (no namespace), exercising a different code path in
+// the Get call than namespaced resources.
+func TestAccWaitResource_PollsForClusterScopedResource(t *testing.T) {
+	t.Parallel()
+
+	raw := os.Getenv("TF_ACC_KUBECONFIG")
+	if raw == "" {
+		t.Fatal("TF_ACC_KUBECONFIG must be set")
+	}
+
+	k8sClient := testhelpers.CreateK8sClient(t, raw)
+	nsName := fmt.Sprintf("wait-cluster-poll-%d", time.Now().UnixNano()%1000000)
+
+	t.Cleanup(func() {
+		_ = k8sClient.CoreV1().Namespaces().Delete(context.Background(), nsName, metav1.DeleteOptions{})
+	})
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"k8sconnect": providerserver.NewProtocol6WithError(k8sconnect.New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					go func() {
+						time.Sleep(90 * time.Second)
+						if err := createNamespaceDirectly(k8sClient, nsName); err != nil {
+							fmt.Printf("Background Namespace creation failed: %v\n", err)
+						} else {
+							fmt.Printf("✅ Background goroutine created Namespace %s\n", nsName)
+						}
+					}()
+				},
+				Config: testAccWaitConfigClusterScopedPoll(nsName),
+				ConfigVariables: config.Variables{
+					"raw": config.StringVariable(raw),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testhelpers.CheckNamespaceExists(k8sClient, nsName),
+					resource.TestCheckResourceAttrSet("k8sconnect_wait.cluster_scoped", "id"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccWaitResource_UnknownKindFailsFast verifies that polling does NOT engage
+// when the resource kind itself is invalid (CRD not installed, typo in kind).
+// GVR discovery fails before polling, so the error message must be the discovery
+// error, not the polling-timeout error.
+//
+// The strict regex is what protects against regression: if polling were
+// engaged on an unknown kind, the resulting error would say "did not appear
+// within" which would not match this regex, failing the test.
+func TestAccWaitResource_UnknownKindFailsFast(t *testing.T) {
+	t.Parallel()
+
+	raw := os.Getenv("TF_ACC_KUBECONFIG")
+	if raw == "" {
+		t.Fatal("TF_ACC_KUBECONFIG must be set")
+	}
+
+	k8sClient := testhelpers.CreateK8sClient(t, raw)
+	nsName := fmt.Sprintf("wait-unknown-kind-%d", time.Now().UnixNano()%1000000)
+	testhelpers.CreateNamespaceDirectly(t, k8sClient, nsName)
+	t.Cleanup(func() {
+		_ = k8sClient.CoreV1().Namespaces().Delete(context.Background(), nsName, metav1.DeleteOptions{})
+	})
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"k8sconnect": providerserver.NewProtocol6WithError(k8sconnect.New()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWaitConfigUnknownKind(nsName),
+				ConfigVariables: config.Variables{
+					"raw": config.StringVariable(raw),
+				},
+				ExpectError: regexp.MustCompile(`(?s)(Failed to Discover GVR|not found in apiVersion)`),
+			},
+		},
+	})
+}
+
+func testAccWaitConfigClusterScopedPoll(nsName string) string {
+	return fmt.Sprintf(`
+variable "raw" {
+  type = string
+}
+
+provider "k8sconnect" {}
+
+resource "k8sconnect_wait" "cluster_scoped" {
+  object_ref = {
+    api_version = "v1"
+    kind        = "Namespace"
+    name        = %q
+  }
+
+  cluster = {
+    kubeconfig = var.raw
+  }
+
+  wait_for = {
+    field   = "metadata.uid"
+    timeout = "180s"
+  }
+}
+`, nsName)
+}
+
+func testAccWaitConfigUnknownKind(namespace string) string {
+	return fmt.Sprintf(`
+variable "raw" {
+  type = string
+}
+
+provider "k8sconnect" {}
+
+resource "k8sconnect_wait" "unknown" {
+  object_ref = {
+    api_version = "fake.example.com/v1"
+    kind        = "NotARealResource"
+    name        = "anything"
+    namespace   = %q
+  }
+
+  cluster = {
+    kubeconfig = var.raw
+  }
+
+  wait_for = {
+    field   = "spec.foo"
+    timeout = "30s"
+  }
+}
+`, namespace)
+}
+
+func createNamespaceDirectly(client kubernetes.Interface, name string) error {
+	ctx := context.Background()
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+	_, err := client.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	return err
+}
+
+// createServiceDirectly creates a minimal Service directly via the K8s client.
+// Used to simulate an operator creating a downstream resource lazily.
+func createServiceDirectly(client kubernetes.Interface, namespace, name string) error {
+	ctx := context.Background()
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Port: 80}},
+		},
+	}
+	_, err := client.CoreV1().Services(namespace).Create(ctx, svc, metav1.CreateOptions{})
+	return err
+}


### PR DESCRIPTION
## Summary

- **wait resource**: polls for the configured object to exist (bounded by wait_for.timeout) instead of fast-failing on NotFound. Fixes #171. Common use case: waiting on resources that operators create lazily after their CR reconciles (Stackgres, cert-manager, ALB controller, etc.).
- **object resource (ADR-023 gap)**: handles auth errors from prepareContext (GVR discovery) during Read the same way as auth errors from Client.Get — degrade to warning, preserve prior state, set stale_read flag. Without this, Read fails with "Preparation Failed" when the token has expired, defeating ADR-023's purpose.
- **expired-token test determinism**: actively polls the API server with the invalidated token until it is rejected before proceeding to the Plan step. Previously the tests passed in CI by timing accident on fast Linux runners (the call landed before SA deletion propagated through the API server's token cache) and failed on macOS where propagation lag exposed the bug. The poll guarantees the auth-error code path is exercised on any environment.

## Test plan

- [x] New acceptance test `TestAccWaitResource_PollsForResourceToExist` (background goroutine creates the Service 90s in; wait polls and succeeds)
- [x] New acceptance test `TestAccWaitResource_TimesOutWhenResourceNeverAppears` (strict regex matching the new timeout error, would fail on pre-fix code)
- [x] New acceptance test `TestAccWaitResource_PollsForClusterScopedResource` (Namespace, exercises cluster-scoped Get path)
- [x] New acceptance test `TestAccWaitResource_UnknownKindFailsFast` (verifies polling does NOT engage for invalid kinds)
- [x] Updated `TestAccObjectResource_ExpiredToken_PlanSucceeds` with `waitForTokenRejection`; verified it now fails without the fix and passes with it
- [x] Updated `TestAccObjectResource_ExpiredToken_DriftDetected` likewise
- [x] All 25 existing wait acceptance tests pass
- [x] Unit tests pass