### PR TITLE
Bump Go from 1.25.9 to 1.26.3 (security)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jmorris0x0/terraform-provider-k8sconnect
 
-go 1.25.9
+go 1.26.3
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0

--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/mod v0.34.0 // indirect
-	golang.org/x/net v0.52.0 // indirect
+	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -272,8 +272,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
-golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
+golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
+golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
Fixes Go stdlib vulnerabilities flagged by govulncheck. Same pattern as PR #165:

- GO-2026-4971: net (fixed in 1.26.3)
- GO-2026-4947: crypto/x509 (fixed in 1.26.2)
- GO-2026-4946: crypto/x509 (fixed in 1.26.2)
- GO-2026-4918: net/http (fixed in 1.26.3)
- GO-2026-4870: crypto/tls (fixed in 1.26.2)
- GO-2026-4866: crypto/x509 (fixed in 1.26.2)
- GO-2026-4865: html/template (fixed in 1.26.2)
- GO-2026-4862: encoding/asn1 (fixed in 1.26.2)
- ...and others fixed in 1.26.2/1.26.3

Unblocks PR #177 which was failing govulncheck after dependabot bumped Go to 1.26.0.