### PR TITLE
Bump Go to 1.26.6 (security)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jmorris0x0/terraform-provider-k8sconnect
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0


### PR DESCRIPTION
Bumps the Go toolchain to 1.26.6.

Go 1.26.5 has three stdlib vulnerabilities (GO-2026-6218 in net/url, GO-2026-6090 in crypto/tls, GO-2026-5972 in encoding/asn1), all fixed in 1.26.6. Unblocks PRs #204 and #198 which fail govulncheck on these.